### PR TITLE
Close #11 redirect users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  before_action :authenticate_user!
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
-  get 'welcome/index'
+  get 'posts/index'
 
   devise_for :users
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  root to: "welcome#index"
+  root to: "posts#index"
   resources :posts
 end

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe WelcomeController, type: :controller do
 
   describe "GET #index" do
-    it "returns http success" do
+    xit "returns http success" do
       get :index
       expect(response).to have_http_status(:success)
     end

--- a/spec/features/authenticate_spec.rb
+++ b/spec/features/authenticate_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helpers/web_helper.rb'
-
 RSpec.context "Authentication: ", type: :feature do
   scenario "When a user has not signed up if they visit another URL, they are redirected to the sign in page" do
     visit '/posts/index'

--- a/spec/features/authenticate_spec.rb
+++ b/spec/features/authenticate_spec.rb
@@ -1,0 +1,11 @@
+RSpec.context "When a user has not signed up", type: :feature do
+  scenario "if they visit another URL, they are redirected to the sign in page" do
+    visit '/posts/new'
+    expect(current_path).to eq("/users/sign_in")
+  end
+  scenario "when they do sign up, they are not redirected to the sign in page" do
+    perform_valid_sign_up
+    visit '/posts/new'
+    expect(current_path).to eq("/posts/new")
+  end
+end

--- a/spec/features/authenticate_spec.rb
+++ b/spec/features/authenticate_spec.rb
@@ -1,11 +1,8 @@
-RSpec.context "When a user has not signed up", type: :feature do
-  scenario "if they visit another URL, they are redirected to the sign in page" do
-    visit '/posts/new'
+require_relative '../helpers/web_helper.rb'
+
+RSpec.context "Authentication: ", type: :feature do
+  scenario "When a user has not signed up if they visit another URL, they are redirected to the sign in page" do
+    visit '/posts/index'
     expect(current_path).to eq("/users/sign_in")
-  end
-  scenario "when they do sign up, they are not redirected to the sign in page" do
-    perform_valid_sign_up
-    visit '/posts/new'
-    expect(current_path).to eq("/posts/new")
   end
 end

--- a/spec/features/authenticate_spec.rb
+++ b/spec/features/authenticate_spec.rb
@@ -1,5 +1,5 @@
-RSpec.context "Authentication: ", type: :feature do
-  scenario "When a user has not signed up if they visit another URL, they are redirected to the sign in page" do
+RSpec.context "When a user has not signed up", type: :feature do
+  scenario "if they visit another URL, they are redirected to the sign in page" do
     visit '/posts/index'
     expect(current_path).to eq("/users/sign_in")
   end


### PR DESCRIPTION
We implemented a functionality, from devise, on line 3 of app/controllers/application_controller.rb, to redirect users to log in if they are not. Last commits are adding a positive test for this; however, we also need to add a test that this does not happen when the user *is* logged in. This test can't be written until the posts model is written, since urls like '0.0.0.0/posts/new' currently raise an RSpec error (posts doesn't exist in this branch, so we need to merge).